### PR TITLE
Added '@pagopa/' to package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "io-functions-public",
+  "name": "@pagopa/io-functions-public",
   "version": "0.4.1",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
In order to generate a correct client SDK, added @pagopa/ to the package name